### PR TITLE
[WIP] when sending data out, output RFC3339

### DIFF
--- a/imls-directus/extensions/migrations/20220630A-timestamptz.js
+++ b/imls-directus/extensions/migrations/20220630A-timestamptz.js
@@ -1,0 +1,35 @@
+module.exports = {
+  async up(knex) {
+    await knex.schema.alterTable('durations', (table) => {
+      // account for UUIDs on windows.
+      table.string('pi_serial', 36).alter();
+      table.renameColumn('pi_serial', 'serial');
+      // convert from seconds since 01-01-1970 to microseconds since 01-01-2000.
+      table.timestamp('tz_start', { useTz: true });
+      table.timestamp('tz_end', { useTz: true });
+      knex('durations').update({
+        tz_start: '(timestamp "epoch" + start * interval "1 second")::timestamptz',
+        tz_end: '(timestamp "epoch" + end * interval "1 second")::timestamptz',
+      })
+      table.dropColumns('start', 'end');
+      table.renameColumn('tz_start', 'start');
+      table.renameColumn('tz_end', 'end');
+    });
+  },
+
+  async down(knex) {
+    await knex.schema.alterTable('durations', (table) => {
+      table.string('serial', 16).alter();
+      table.renameColumn('serial', 'pi_serial');
+      table.bigInteger('nontz_start', { useTz: true });
+      table.bigInteger('nontz_end', { useTz: true });
+      knex('durations').update({
+        nontz_start: 'extract(epoch from "start")',
+        nontz_end: 'extract(epoch from "end")',
+      })
+      table.dropColumns('start', 'end');
+      table.renameColumn('nontz_start', 'start');
+      table.renameColumn('nontz_end', 'end');
+    });
+  },
+};

--- a/imls-raspberry-pi/Makefile
+++ b/imls-raspberry-pi/Makefile
@@ -14,7 +14,7 @@ endif
 endif
 
 check-install:
-	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
 
 check:
 	golangci-lint run ./...
@@ -25,15 +25,15 @@ deps:
 	go mod download
 
 session-counter: deps
-	${ENVVARS} GOPATH=$$PWD/../release go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/session-counter
+	${ENVVARS} GOPATH=${RELEASEPATH} go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/session-counter
 
 wifi-hardware-search-cli: deps
-	${ENVVARS} GOPATH=$$PWD/../release go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/wifi-hardware-search-cli
+	${ENVVARS} GOPATH=${RELEASEPATH} go install -ldflags $(LDFLAGS) gsa.gov/18f/cmd/wifi-hardware-search-cli
 
 clean:
-	mkdir -p ../release/{bin,pkg}
-	chmod -R +w ../release/{bin,pkg}*
-	rm -rf ../release/{bin,pkg}
+	mkdir -p ${RELEASEPATH}/{bin,pkg}
+	chmod -R +w ${RELEASEPATH}/{bin,pkg}*
+	rm -rf ${RELEASEPATH}/{bin,pkg}
 
 test:
 	make -C internal/wifi-hardware-search test

--- a/imls-raspberry-pi/cmd/session-counter/tlp/process_data.go
+++ b/imls-raspberry-pi/cmd/session-counter/tlp/process_data.go
@@ -2,6 +2,7 @@ package tlp
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"gsa.gov/18f/internal/interfaces"
@@ -33,9 +34,9 @@ func ProcessData(dDB interfaces.Database, sq *state.Queue, iq *state.Queue) bool
 			FCFSSeqID: state.GetFCFSSeqID(),
 			DeviceTag: state.GetDeviceTag(),
 			PatronID:  pidCounter,
-			// FIXME: All times should become UNIX epoch seconds...
-			Start: se.Start,
-			End:   se.End}
+			Start:     time.Unix(se.Start, 0).Format(time.RFC3339),
+			End:       time.Unix(se.End, 0).Format(time.RFC3339),
+		}
 
 		//dDB.GetTableFromStruct(structs.Duration{}).InsertStruct(d)
 		durations = append(durations, d)

--- a/imls-raspberry-pi/internal/analysis/drawing.go
+++ b/imls-raspberry-pi/internal/analysis/drawing.go
@@ -32,8 +32,8 @@ func DrawPatronSessions(durations []structs.Duration, outputPath string) {
 		Msg("iterating")
 
 	for _, d := range durations {
-		st := time.Unix(d.Start, 0).In(time.Local)
-		et := time.Unix(d.End, 0).In(time.Local)
+		st, _ := time.Parse(time.RFC3339, d.Start)
+		et, _ := time.Parse(time.RFC3339, d.End)
 		diff := int(et.Sub(st).Minutes())
 		// log.Println("st", st, "et", et, "diff", diff)
 		if isInDurationRange(diff) {
@@ -72,8 +72,8 @@ func DrawPatronSessions(durations []structs.Duration, outputPath string) {
 
 	for _, d := range durations {
 		// lw.Debug("duration ", d)
-		st := time.Unix(d.Start, 0).In(time.Local)
-		et := time.Unix(d.End, 0).In(time.Local)
+		st, _ := time.Parse(time.RFC3339, d.Start)
+		et, _ := time.Parse(time.RFC3339, d.End)
 		diff := int(et.Sub(st).Minutes())
 
 		totalPatrons += 1
@@ -156,7 +156,7 @@ func DrawPatronSessions(durations []structs.Duration, outputPath string) {
 
 	}
 
-	day := time.Unix(durations[0].Start, 0).In(time.Local)
+	day, _ := time.Parse(time.RFC3339, durations[0].Start)
 	summaryD := fmt.Sprintf("Patron sessions from %v %v, %v - %v %v", day.Month(), day.Day(), day.Year(), config.GetFCFSSeqID(), config.GetDeviceTag())
 	summaryA := fmt.Sprintf("%v devices seen", totalPatrons)
 	summaryP := fmt.Sprintf("%v patron devices", durationsInRange)

--- a/imls-raspberry-pi/internal/structs/durations.go
+++ b/imls-raspberry-pi/internal/structs/durations.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 )
 
 type ByStart []Duration
 
 func (a ByStart) Len() int { return len(a) }
 func (a ByStart) Less(i, j int) bool {
-	// it, _ := time.Parse(time.RFC3339, a[i].Start)
-	// jt, _ := time.Parse(time.RFC3339, a[j].Start)
-	return a[i].Start < a[j].Start
-	//return it.Before(jt)
+	it, _ := time.Parse(time.RFC3339, a[i].Start)
+	jt, _ := time.Parse(time.RFC3339, a[j].Start)
+	return it.Before(jt)
 }
 func (a ByStart) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
@@ -28,8 +28,8 @@ type Duration struct {
 	FCFSSeqID string `json:"fcfs_seq_id" db:"fcfs_seq_id" type:"TEXT"`
 	DeviceTag string `json:"device_tag" db:"device_tag" type:"TEXT"`
 	PatronID  int    `json:"patron_index" db:"patron_index" type:"INTEGER"`
-	Start     int64  `json:"start,string" db:"start" type:"INTEGER"`
-	End       int64  `json:"end,string" db:"end" type:"INTEGER"`
+	Start     string `json:"start,string" db:"start" type:"DATE"`
+	End       string `json:"end,string" db:"end" type:"DATE"`
 }
 
 func (d Duration) AsMap() map[string]interface{} {


### PR DESCRIPTION
Set up proper datetime display on directus. 

- session-counter now outputs RFC3339 dates (e.g., `2022-06-12T07:20:50.52+02:00`) instead of unix epochs
- migration: `pi_serial`/16 chars to `serial`/36 chars to accommodate windows use case
- migration: `start` and `end` to `timestamptz` (previously was `bigint`)
- TODO: make all fields required (non-NULL)